### PR TITLE
feat: add check_data_freshness meta-tool (Phase D D.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ COPY --from=builder /app/dist ./dist
 # This file MUST exist — run `npm run build:db` (or full pipeline) first
 COPY data/database.db ./data/database.db
 
+# Copy data sources manifest (read by check_data_freshness tool at runtime)
+COPY sources.yml ./sources.yml
+
 # ───────────────────────────────────────────────────────────────────────────
 # SECURITY
 # ───────────────────────────────────────────────────────────────────────────

--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
     { "name": "get_speech" },
     { "name": "format_citation" },
     { "name": "list_sources" },
-    { "name": "about" }
+    { "name": "about" },
+    { "name": "check_data_freshness" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,29 @@
 {
-  "name": "@ansvar/norwegian-law-mcp",
+  "name": "@ansvar/norwegian-parliamentary-debates-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ansvar/norwegian-law-mcp",
+      "name": "@ansvar/norwegian-parliamentary-debates-mcp",
       "version": "0.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@ansvar/mcp-sqlite": "^1.0.3",
-        "@modelcontextprotocol/sdk": "^1.25.3"
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
-        "norwegian-law-mcp": "dist/index.js"
+        "norwegian-parliamentary-debates-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/jsdom": "^21.1.7",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.15.29",
         "@vitest/coverage-v8": "^4.0.18",
         "better-sqlite3": "^12.6.2",
         "fast-xml-parser": "^5.3.5",
-        "jsdom": "^27.4.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -37,7 +37,9 @@
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@ansvar/mcp-sqlite": {
       "version": "1.0.3",
@@ -57,6 +59,8 @@
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
         "@csstools/css-color-parser": "^4.0.1",
@@ -71,6 +75,8 @@
       "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
@@ -84,7 +90,9 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -162,6 +170,8 @@
         }
       ],
       "license": "MIT-0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -182,6 +192,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -206,6 +218,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.1",
         "@csstools/css-calc": "^3.0.0"
@@ -234,6 +248,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -256,7 +272,9 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -274,6 +292,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -328,6 +348,8 @@
       "integrity": "sha512-VnfL2lS43Z9F8li1faMH9hDZwqfrF5JvOePmrF8oESfo0ijaujnT81zYtienQRpoFa+FJbq0E5rrnMWEW73gOw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -503,17 +525,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/jsdom": {
-      "version": "21.1.7",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.11",
@@ -524,13 +541,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.18",
@@ -693,6 +703,8 @@
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -729,6 +741,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -794,6 +812,8 @@
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -994,6 +1014,8 @@
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
@@ -1008,6 +1030,8 @@
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
@@ -1024,6 +1048,8 @@
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^15.1.0"
@@ -1038,6 +1064,8 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -1064,7 +1092,9 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -1156,6 +1186,8 @@
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -1627,6 +1659,8 @@
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -1667,6 +1701,8 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -1681,6 +1717,8 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -1762,7 +1800,9 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -1831,12 +1871,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -1877,6 +1931,8 @@
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -1902,6 +1958,8 @@
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -1958,7 +2016,9 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -2149,19 +2209,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2329,6 +2376,8 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2516,6 +2565,8 @@
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -2818,7 +2869,9 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",
@@ -2907,6 +2960,8 @@
       "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.0.23"
       },
@@ -2919,7 +2974,9 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
       "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -2936,6 +2993,8 @@
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -2949,6 +3008,8 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -3208,6 +3269,8 @@
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -3221,6 +3284,8 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -3231,6 +3296,8 @@
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3241,6 +3308,8 @@
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.0"
@@ -3293,6 +3362,8 @@
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3315,6 +3386,8 @@
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3324,7 +3397,9 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
   },
   "dependencies": {
     "@ansvar/mcp-sqlite": "^1.0.3",
-    "@modelcontextprotocol/sdk": "^1.25.3"
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.15.29",
     "@vitest/coverage-v8": "^4.0.18",
     "better-sqlite3": "^12.6.2",

--- a/sources.yml
+++ b/sources.yml
@@ -11,6 +11,7 @@ sources:
     artifact_url: "https://www.clarin.si/repository/xmlui/bitstream/handle/11356/1486/ParlaMint-NO.tgz?sequence=19&isAllowed=y"
     update_frequency: "static (v3.0 released 2023-06-17, no further updates expected)"
     last_ingested: "2026-05-02"
+    last_verified: "2026-05-09"
     license_or_terms:
       type: "CC BY 4.0 (Creative Commons Attribution 4.0 International)"
       url: "https://creativecommons.org/licenses/by/4.0/"

--- a/src/tools/check-data-freshness.ts
+++ b/src/tools/check-data-freshness.ts
@@ -1,0 +1,93 @@
+/**
+ * check_data_freshness — mandatory meta-tool per law-mcp-golden-standard §4.1.
+ *
+ * Returns the corpus build timestamp and per-source last_verified dates with
+ * staleness_days computed against a configurable threshold (default 90 days).
+ * The watchdog probes this tool to alert on stale data; consumers call it to
+ * verify the corpus is current before acting on results.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import type Database from '@ansvar/mcp-sqlite';
+import { readDbMetadata } from '../capabilities.js';
+
+const DEFAULT_STALENESS_THRESHOLD_DAYS = 90;
+const UNKNOWN_STALENESS_DAYS = 999;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+const MS_PER_DAY = 86_400_000;
+
+export interface SourceFreshness {
+  publisher: string;
+  source_url: string;
+  last_verified: string;
+  staleness_days: number;
+}
+
+export interface CheckDataFreshnessResult {
+  build_timestamp: string;
+  sources: SourceFreshness[];
+  has_stale_sources: boolean;
+  staleness_threshold_days: number;
+}
+
+export interface CheckDataFreshnessOptions {
+  /** Path to sources.yml. Defaults to `<cwd>/sources.yml`. */
+  sourcesYmlPath?: string;
+  /** Days past `last_verified` before a source is considered stale. */
+  thresholdDays?: number;
+  /** Reference time for staleness computation. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+interface SourceEntry {
+  name?: string;
+  authority?: string;
+  official_portal?: string;
+  last_verified?: string;
+}
+
+interface SourcesYml {
+  sources?: SourceEntry[];
+}
+
+function computeStaleness(lastVerified: string | undefined, nowMs: number): number {
+  if (!lastVerified || !ISO_DATE.test(lastVerified)) {
+    return UNKNOWN_STALENESS_DAYS;
+  }
+  const parsed = Date.parse(lastVerified);
+  if (Number.isNaN(parsed)) {
+    return UNKNOWN_STALENESS_DAYS;
+  }
+  return Math.floor((nowMs - parsed) / MS_PER_DAY);
+}
+
+export function checkDataFreshness(
+  db: InstanceType<typeof Database>,
+  options: CheckDataFreshnessOptions = {},
+): CheckDataFreshnessResult {
+  const thresholdDays = options.thresholdDays ?? DEFAULT_STALENESS_THRESHOLD_DAYS;
+  const nowMs = (options.now ?? new Date()).getTime();
+  const sourcesYmlPath = options.sourcesYmlPath ?? resolve(process.cwd(), 'sources.yml');
+
+  const meta = readDbMetadata(db);
+  const buildTimestamp = meta.built_at;
+
+  const yml = (yaml.load(readFileSync(sourcesYmlPath, 'utf8')) ?? {}) as SourcesYml;
+  const entries = yml.sources ?? [];
+
+  const sources: SourceFreshness[] = entries.map((s) => ({
+    publisher: s.authority ?? s.name ?? 'unknown',
+    source_url: s.official_portal ?? '',
+    last_verified: s.last_verified ?? 'unknown',
+    staleness_days: computeStaleness(s.last_verified, nowMs),
+  }));
+
+  return {
+    build_timestamp: buildTimestamp,
+    sources,
+    has_stale_sources: sources.some((s) => s.staleness_days > thresholdDays),
+    staleness_threshold_days: thresholdDays,
+  };
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,6 +19,7 @@ import { getSpeech, GetSpeechInput } from './get-speech.js';
 import { formatCitationTool, FormatCitationInput } from './format-citation.js';
 import { getAbout, type AboutContext } from './about.js';
 import { listSources } from './list-sources.js';
+import { checkDataFreshness } from './check-data-freshness.js';
 
 export type { AboutContext } from './about.js';
 
@@ -39,6 +40,18 @@ const ABOUT_TOOL: Tool = {
   description:
     'Server metadata, dataset statistics, and provenance. ' +
     'Call this to verify data coverage, corpus version, and attribution before citing results.',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+const CHECK_DATA_FRESHNESS_TOOL: Tool = {
+  name: 'check_data_freshness',
+  description:
+    'Returns the corpus build timestamp and per-source last_verified dates with staleness_days against a 30-day threshold (ParlaMint-NO is a static archival corpus, but verification cadence is monthly). ' +
+    'Use this to verify whether the data backing this MCP is current before relying on it for compliance work. ' +
+    'For full source provenance, use list_sources; for server statistics, use about.',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -143,7 +156,9 @@ export const TOOLS: Tool[] = [
 ];
 
 export function buildTools(context?: AboutContext): Tool[] {
-  return context ? [...TOOLS, LIST_SOURCES_TOOL, ABOUT_TOOL] : [...TOOLS, LIST_SOURCES_TOOL];
+  return context
+    ? [...TOOLS, LIST_SOURCES_TOOL, CHECK_DATA_FRESHNESS_TOOL, ABOUT_TOOL]
+    : [...TOOLS, LIST_SOURCES_TOOL, CHECK_DATA_FRESHNESS_TOOL];
 }
 
 export function registerTools(
@@ -181,6 +196,9 @@ export function registerTools(
 
         case 'list_sources':
           result = listSources(db);
+          break;
+        case 'check_data_freshness':
+          result = checkDataFreshness(db, { thresholdDays: 30 });
           break;
 
         case 'about':

--- a/tests/check-data-freshness.test.ts
+++ b/tests/check-data-freshness.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from '@ansvar/mcp-sqlite';
+import { checkDataFreshness } from '../src/tools/check-data-freshness.js';
+
+function addMetadata(db: InstanceType<typeof Database>, entries: Record<string, string>): void {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS db_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+  ).run();
+  const insert = db.prepare('INSERT INTO db_metadata (key, value) VALUES (?, ?)');
+  for (const [k, v] of Object.entries(entries)) {
+    insert.run(k, v);
+  }
+}
+
+describe('check_data_freshness', () => {
+  let db: InstanceType<typeof Database>;
+  let tmp: string;
+  let sourcesPath: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    tmp = mkdtempSync(join(tmpdir(), 'cdf-test-'));
+    sourcesPath = join(tmp, 'sources.yml');
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns build_timestamp and per-source last_verified with staleness_days', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Lovdata API"
+    authority: "Stiftelsen Lovdata"
+    official_portal: "https://api.lovdata.no/"
+    last_verified: "2026-05-09"
+`,
+    );
+    const now = new Date('2026-05-09T12:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.build_timestamp).toBe('2026-05-02T10:00:00.000Z');
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0].publisher).toBe('Stiftelsen Lovdata');
+    expect(result.sources[0].source_url).toBe('https://api.lovdata.no/');
+    expect(result.sources[0].last_verified).toBe('2026-05-09');
+    expect(result.sources[0].staleness_days).toBe(0);
+    expect(result.has_stale_sources).toBe(false);
+    expect(result.staleness_threshold_days).toBe(90);
+  });
+
+  it('flags has_stale_sources when any source is past the 90-day threshold', () => {
+    addMetadata(db, { built_at: '2026-01-01T00:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Recent source"
+    authority: "Recent"
+    last_verified: "2026-04-15"
+  - name: "Stale source"
+    authority: "Stale"
+    last_verified: "2026-01-15"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.sources).toHaveLength(2);
+    const recent = result.sources.find((s) => s.publisher === 'Recent')!;
+    const stale = result.sources.find((s) => s.publisher === 'Stale')!;
+    expect(recent.staleness_days).toBeLessThanOrEqual(90);
+    expect(stale.staleness_days).toBeGreaterThan(90);
+    expect(result.has_stale_sources).toBe(true);
+  });
+
+  it('returns staleness_days=999 when last_verified is missing or non-ISO', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "No date"
+    authority: "Missing"
+  - name: "Bad date"
+    authority: "Invalid"
+    last_verified: "TBD"
+`,
+    );
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath });
+
+    expect(result.sources[0].staleness_days).toBe(999);
+    expect(result.sources[1].staleness_days).toBe(999);
+    expect(result.has_stale_sources).toBe(true);
+  });
+
+  it('returns build_timestamp="unknown" when db_metadata is missing', () => {
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "X"
+    authority: "Y"
+    last_verified: "2026-05-09"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.build_timestamp).toBe('unknown');
+  });
+
+  it('honours a custom thresholdDays option', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Daily source"
+    authority: "Court feed"
+    last_verified: "2026-05-01"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, {
+      sourcesYmlPath: sourcesPath,
+      thresholdDays: 7,
+      now,
+    });
+
+    expect(result.staleness_threshold_days).toBe(7);
+    expect(result.sources[0].staleness_days).toBe(8);
+    expect(result.has_stale_sources).toBe(true);
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -22,15 +22,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DB_PATH = path.resolve(__dirname, '../data/database.db');
 
-describe('norwegian-parliamentary-debates-mcp smoke', () => {
+// Skip the whole smoke suite when no usable DB is present. Pattern from
+// feedback_contract_test_skip_on_empty_db_2026_05_07.md.
+const dbReady =
+  fs.existsSync(DB_PATH) && fs.statSync(DB_PATH).size > 1024;
+const describeFn = dbReady ? describe : describe.skip;
+
+describeFn('norwegian-parliamentary-debates-mcp smoke', () => {
   let db: InstanceType<typeof Database>;
 
   beforeAll(() => {
-    if (!fs.existsSync(DB_PATH)) {
-      throw new Error(
-        `Database not found at ${DB_PATH}. Run \`npm run ingest\` and \`npm run build:db\` before tests.`,
-      );
-    }
     db = new Database(DB_PATH, { readonly: true });
   });
 


### PR DESCRIPTION
Phase D D.7 — adds check_data_freshness meta-tool per law-mcp-golden-standard §4.1. Templates from D.1 reference (Norwegian-law-mcp #61 + #62).

Three changes per the post-D.1 recipe:
- src/tools/check-data-freshness.ts + tests/check-data-freshness.test.ts (5 specs) — verbatim from D.1.
- sources.yml — added `last_verified:"2026-05-09"` to ParlaMint-NO source.
- Dockerfile — COPY sources.yml ./sources.yml in runtime stage.

**Per-repo threshold:** registry dispatch passes `thresholdDays: 30` because ParlaMint-NO is a static archival corpus (released 2023-06-17, no further updates expected) but verification cadence is monthly. Per Phase G plan §G.1 Step 3.

**Prereq fix:**
- tests/smoke.test.ts: changed `throw new Error` on missing DB to `describe.skip` pattern.

Phase A (apply-mcp-standard.py) work deferred to Phase G per plan §G.1 Step 2.

This MCP runs on prod as `law-norwegian-parliamentary-debates:0.1.0`. Per the handover, Phase G handles the version bump + prod compose entry — no recreate needed for this PR.

Verification: typecheck clean, 5 new specs pass, smoke skips cleanly when DB absent.

Plan: docs/superpowers/plans/2026-05-09-nordic-golden-standard-rollout.md (Phase D Task D.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)